### PR TITLE
Corrects existing bug on missing FOLLOW relations

### DIFF
--- a/discourse_forum/discourse_forum/spiders/discourse_spider.py
+++ b/discourse_forum/discourse_forum/spiders/discourse_spider.py
@@ -13,7 +13,6 @@ import scrapy
 from scrapy import Selector
 
 from neo4j import GraphDatabase
-import time
 
 SITEMAP_REQUEST_CONNECT_TIMEOUT = 5
 SITEMAP_REQUEST_READ_TIMEOUT = 10


### PR DESCRIPTION
Resolves the issue on missing `FOLLOW` relations between consecutive nodes.

One can still verify that there positions to which we miss the post (namely `[29, 41, 75, 78, 80, 88, 89, 104, 185, 201, 204, 206, 231, 242, 258, 269, 270, 278, 299]`, for `thread_id = 1e1f33a4`). 

But these are missing from the native html source code, noticed after manual checking.